### PR TITLE
fix implicit catch statements

### DIFF
--- a/source/libdmathexpr/mathexpr.d
+++ b/source/libdmathexpr/mathexpr.d
@@ -96,7 +96,7 @@ interface IMathObject {
 const string tryEval = 
 "		try {
 			return new MONumber(evaluate(vars));
-		} catch {}";
+		} catch(Exception) {}";
 
 enum MOOpType {
 	Addition,
@@ -886,7 +886,7 @@ unittest {
 		try {
 			parseMathExpr(expr).evaluate(vars);
 			assert(0);
-		} catch {}
+		} catch(Exception) {}
 	}
 	void setVar(string var,real val) {
 		vars[var] = val;


### PR DESCRIPTION
catch without a specified type was deprecated back in D 2.072.

This technically changes the behaviour slightly, but catching Error may not have been intended anyway?