### PR TITLE
use approxEqual instead of == to avoid reliability issues

### DIFF
--- a/source/libdmathexpr/mathexpr.d
+++ b/source/libdmathexpr/mathexpr.d
@@ -48,6 +48,9 @@ version(Tango) {
 		auto rgxp = Regex(pattern,"g");
 		return rgxp.replaceAll(input,&tmpdel);
 	}
+	bool approxEqual(real a,real b) {
+		return a == b;
+	}
 } else {
 	version(D_Version2) {
 		import std.conv:to;
@@ -879,7 +882,7 @@ void main() {}
 	real[string]vars;
 	void tryGood(string expr,real expected) @safe {
 		logln("MathExpr: "~expr~" == "~tostring(expected)~"\n");
-		assert(parseMathExpr(expr).evaluate(vars) == expected);
+		assert(approxEqual(parseMathExpr(expr).evaluate(vars), expected));
 	}
 	void tryBad(string expr) @safe {
 		logln("MathExpr: "~expr~" (intentional bad expression)\n");


### PR DESCRIPTION
Given how much reals vary from platform to platform, using == in tests is pretty unreliable - ex: windows x86 passed unittests, but x86-64 did not. Other platforms, especially those with a different real size, were likely impacted as well.

I'm not sure if using tango with this library is still supported, or if it even has a similar function, so that version has a function emulating the old behaviour.